### PR TITLE
Fix build on Linux host.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ INC       := $(INC) $(GMPINC)
 # use the second line to disable profiling instrumentation
 # PROFILING := -pg
 PROFILING :=
-CCFLAGS   := -Wall $(INC) $(CONFIG) -O2 -DNDEBUG $(PROFILING)
+CCFLAGS   := -fPIC -Wall $(INC) $(CONFIG) -O2 -DNDEBUG $(PROFILING)
 CXXFLAGS  := $(CCFLAGS) $(CPP11_FLAGS)
 CCDFLAGS  := -Wall $(INC) $(CONFIG) -ggdb
 CXXDFLAGS := $(CCDFLAGS)
@@ -193,7 +193,7 @@ bin/off2obj: obj/off2obj.o
 
 obj/isct/triangle.o: src/isct/triangle.c
 	@echo "Compiling the Triangle library"
-	@$(CC) -O2 -DNO_TIMER \
+	@$(CC) $(CCFLAGS) -O2 -DNO_TIMER \
                -DREDUCED \
                -DCDT_ONLY -DTRILIBRARY \
                -Wall -DANSI_DECLARATORS \

--- a/src/mesh/mesh.isct.tpp
+++ b/src/mesh/mesh.isct.tpp
@@ -650,14 +650,14 @@ public:
 	// DGM: to replace lambda in IsctProblem constructor!
 	void quantizeVerts(const Quantization& quantizer)
 	{
-		if (!mesh)
+		if (!TopoCache::mesh)
 			return;
 
-		size_t N = mesh->verts.size();
+		size_t N = TopoCache::mesh->verts.size();
 		quantized_coords.resize(N);
 
 		uint write = 0;
-		for (Vptr v = verts.getFirst(); v != NULL; v = verts.getNext(v))
+		for (Vptr v = TopoCache::verts.getFirst(); v != NULL; v = TopoCache::verts.getNext(v))
 		{
 #ifdef _WIN32
 			Vec3d raw = mesh->verts[v->ref].pos;

--- a/src/mesh/mesh.isct.tpp
+++ b/src/mesh/mesh.isct.tpp
@@ -1106,7 +1106,7 @@ void Mesh<VertData,TriData>::IsctProblem::findIntersections()
     if(nTrys <= 0) {
         CORK_ERROR("Ran out of tries to perturb the mesh");
 		//std::logic_error
-		throw std::exception("Ran out of tries to perturb the mesh");
+		throw std::runtime_error("Ran out of tries to perturb the mesh");
         //exit(1);
     }
     

--- a/src/mesh/mesh.topoCache.tpp
+++ b/src/mesh/mesh.topoCache.tpp
@@ -504,7 +504,7 @@ void Mesh<VertData, TriData>::TopoCache::print()
     cout << "TRIS" << endl;
     int tri_count = 0;
     tris.for_each([&](Tptr t) {
-        cout << " " << t << ": " << *t << endl;
+        cout << " " << t << ": " << endl;
         tri_count++;
     });
     cout << "There were " << tri_count << " TRIS" << endl;

--- a/src/util/prelude.h
+++ b/src/util/prelude.h
@@ -60,7 +60,7 @@ std::ostream &err();
         err()     << "ENSURE FAILED at " \
                   << __FILE__ << ", line #" << __LINE__ << ":\n" \
                   << "    " << #STATEMENT << std::endl; \
-		throw std::exception("ENSURE FAILED"); \
+		throw std::runtime_error("ENSURE FAILED"); \
     } \
 }
 #endif // ENSURE


### PR DESCRIPTION
- [x] Fix `std::exception()` not having constructor for `string` arg.
- [x] Fix `mash` missing namespace specifier.
- [ ] No casting form `TopoTri` to `std::ostream` ( `CXXFLAGS+=" -DSUPPORT_TOPO_STREAM_OPERATORS"` in both cork/couldcompare)